### PR TITLE
improve border-radius value

### DIFF
--- a/paper-fab.css
+++ b/paper-fab.css
@@ -3,14 +3,13 @@
   width: 56px;
   height: 56px;
   background: #d23f31;
-  border-radius: 28px;
+  border-radius: 50%;
   fill: #fff;
 }
 
 :host(.mini) {
   width: 40px;
   height: 40px;
-  border-radius: 20px;
 }
 
 :host /deep/ #focusBg {


### PR DESCRIPTION
Instead of using border-radius: 28px for the normal fab, and 20px for the small fab, use border-radius: 50%. This will always make the element a circle no matter what the height and width is.
