### PR TITLE
mini is now an attribute, not class

### DIFF
--- a/paper-fab.html
+++ b/paper-fab.html
@@ -13,7 +13,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 Material Design: <a href="https://spec.googleplex.com/quantum/components/buttons.html">Button</a>
 
 `paper-fab` is a floating action button. It contains an image placed in the center and
-comes in two sizes: regular size and a smaller size by applying the class `mini`. When
+comes in two sizes: regular size and a smaller size by applying the attribute `mini`. When
 the user touches the button, a ripple effect emanates from the center of the button.
 
 You may import `core-icons` to use with this element, or provide an URL to a custom icon.


### PR DESCRIPTION
The docs implied that `mini` was still a class name.
