### PR TITLE
Allow content to be added to fab

### DIFF
--- a/paper-fab.html
+++ b/paper-fab.html
@@ -122,7 +122,7 @@ you should ensure that the `aria-label` attribute is set.
     </template>
 
     <!-- to position to ripple behind the icon -->
-    <core-icon relative id="icon" src="{{src}}" icon="{{icon}}"></core-icon>
+    <core-icon relative id="icon" src="{{src}}" icon="{{icon}}"><content></content></core-icon>
 
   </template>
 


### PR DESCRIPTION
`icon` and `src` do not give enough flexibility/control over the content in a fab. In my case I wish to add a morphing icon to the icon. Something like: http://codepen.io/albebonv/pen/mKpjg
